### PR TITLE
Fix: messages not visible 

### DIFF
--- a/consumer/record_processor.py
+++ b/consumer/record_processor.py
@@ -20,7 +20,7 @@ formatter = logging.Formatter(
         '%(asctime)s.%(msecs)03d [%(module)s] %(levelname)s  %(funcName)s - %(message)s',
         '%H:%M:%S'
 )
-handler = handlers.RotatingFileHandler('/app/logs/record_processor.log', maxBytes=1000, backupCount=5)
+handler = handlers.RotatingFileHandler('/app/logs/record_processor.log', maxBytes=10**6, backupCount=5)
 handler.setLevel(logging.INFO)
 handler.setFormatter(formatter)
 logger.addHandler(handler)

--- a/consumer/run.sh
+++ b/consumer/run.sh
@@ -3,4 +3,4 @@ python3 /usr/bin/set_properties.py
 chmod 777 /usr/bin/record_processor.py
 `python3 /usr/bin/amazon_kclpy_helper.py --print_command --java /usr/bin/java --properties /usr/bin/record_processor.properties --log-configuration /usr/bin/logback.xml` &
 touch /app/logs/record_processor.log
-exec tail -f /app/logs/record_processor.log
+exec tail -F /app/logs/record_processor.log


### PR DESCRIPTION
*Description of changes:*

Messages larger than 1000 bytes are not visible in the logs, because the log file immediately gets rotated away. `tail -f` fails to recognize that log files have been rotated away and continues to read from the original inode. As a result, messages consumed by the application are not visible in the log stream.

Fixed in the commits of this PR.