### PR TITLE
Upgrade consumer to the latest standards

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,6 +1,7 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum install python3 git java-11-amazon-corretto-headless -y
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+RUN yum install python3-pip git java-11-amazon-corretto-headless -y
 RUN git clone --depth 1 --branch v2.1.1 https://github.com/awslabs/amazon-kinesis-client-python
+RUN pip3 install setuptools
 RUN cd amazon-kinesis-client-python &&\
     python3 setup.py download_jars &&\
     python3 setup.py install &&\

--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN yum install python3-pip git java-11-amazon-corretto-headless -y
-RUN git clone --depth 1 --branch v2.1.1 https://github.com/awslabs/amazon-kinesis-client-python
+RUN git clone --depth 1 --branch v3.0.1 https://github.com/awslabs/amazon-kinesis-client-python
 RUN pip3 install setuptools
 RUN cd amazon-kinesis-client-python &&\
     python3 setup.py download_jars &&\

--- a/consumer/run.sh
+++ b/consumer/run.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
+# transform sample.properties into record_processor.properties
 python3 /usr/bin/set_properties.py
+
 chmod 777 /usr/bin/record_processor.py
-`python3 /usr/local/lib/python3.9/site-packages/samples/amazon_kclpy_helper.py --print_command --java /usr/bin/java --properties /usr/bin/record_processor.properties --log-configuration /usr/bin/logback.xml` &
+command=$(python3 /usr/local/lib/python3.9/site-packages/samples/amazon_kclpy_helper.py --print_command --java /usr/bin/java --properties /usr/bin/record_processor.properties --log-configuration /usr/bin/logback.xml)
+# execute the generated command in the background (&)
+eval "${command}" &
+
 mkdir -p /app/logs
 touch /app/logs/record_processor.log
 exec tail -F /app/logs/record_processor.log

--- a/consumer/run.sh
+++ b/consumer/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 python3 /usr/bin/set_properties.py
 chmod 777 /usr/bin/record_processor.py
-`python3 /usr/local/lib/python3.7/site-packages/samples/amazon_kclpy_helper.py --print_command --java /usr/bin/java --properties /usr/bin/record_processor.properties --log-configuration /usr/bin/logback.xml` &
+`python3 /usr/local/lib/python3.9/site-packages/samples/amazon_kclpy_helper.py --print_command --java /usr/bin/java --properties /usr/bin/record_processor.properties --log-configuration /usr/bin/logback.xml` &
 mkdir -p /app/logs
 touch /app/logs/record_processor.log
 exec tail -F /app/logs/record_processor.log

--- a/consumer/sample.properties
+++ b/consumer/sample.properties
@@ -12,10 +12,12 @@ streamName = STREAM_NAME
 applicationName = APPLICATION_NAME
 
 # Users can change the credentials provider the KCL will use to retrieve credentials.
-# The DefaultAWSCredentialsProviderChain checks several other providers, which is
+# Expected key name (case-sensitive):
+# AwsCredentialsProvider / AwsCredentialsProviderDynamoDB / AwsCredentialsProviderCloudWatch
+# The DefaultCredentialsProvider checks several other providers, which is
 # described here:
-# http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
-AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
+# https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
+AwsCredentialsProvider = DefaultCredentialsProvider
 
 # Appended to the user agent of the KCL. Does not impact the functionality of the
 # KCL in any other way.

--- a/consumer/sample.properties
+++ b/consumer/sample.properties
@@ -19,7 +19,7 @@ AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
 
 # Appended to the user agent of the KCL. Does not impact the functionality of the
 # KCL in any other way.
-processingLanguage = python/3.6
+processingLanguage = python/3.9
 
 # Valid options at TRIM_HORIZON or LATEST.
 # See http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax


### PR DESCRIPTION
*Description of changes:*
* upgrade docker image to amazonlinux:2023 with python 3.9
* use Java SDK v2 `DefaultCredentialsProvider` to allow credentials via a task role
* improve run.sh script for readability